### PR TITLE
add the SNAP status board to the office-screen

### DIFF
--- a/status-board.html
+++ b/status-board.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
+	"http://www.w3.org/TR/html4/frameset.dtd">
+<html lang="en">
+<head>
+	<!--
+	
+	    After a half minute, head on over to CfA Website Dashboard
+	
+	-->
+	<meta http-equiv="refresh" content="60; url=website-dashboard.html">
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<title>SNAP Status Board</title>
+</head>
+<frameset rows="*, 40" border="0">
+<frame frameborder="0" scrolling="no" src="http://uptime.statuscake.com/?TestID=pQYuAW4tAi">
+<frame frameborder="0" scrolling="no" src="footer.html">
+</frameset>
+</html>


### PR DESCRIPTION
Simply adding the SNAP uptime status board to the rotating selection of office-screen sites.
