### PR TITLE
Adding fellowship and summit metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Index
 ⟶ [CfA Website Dashboard](http://codeforamerica.github.io/office-screen/website-dashboard.html)
 ⟶ [Health Ducksboard](http://codeforamerica.github.io/office-screen/ducksboard.html)
 ⟶ [CfA Org Metrics](http://codeforamerica.github.io/office-screen/org-metrics.html)
+⟶ [CfA Current Goals](http://codeforamerica.github.io/office-screen/current-events.html)
 ↩
 
 

--- a/current-events.html
+++ b/current-events.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
+	"http://www.w3.org/TR/html4/frameset.dtd">
+<html lang="en">
+<head>
+  <!--
+  
+        After 90 seconds, head on over to Tweetbeam.
+  
+  -->
+  <meta http-equiv="refresh" content="90; url=tweetbeam.html">
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<title>Code for America Project Monitor</title>
+</head>
+<frameset rows="*, 40" border="0">
+<frame frameborder="0" scrolling="no" src="http://codeforamerica.github.io/cfa-numbers/current-events/">
+<frame frameborder="0" scrolling="no" src="footer.html">
+</frameset>
+</html>

--- a/org-metrics.html
+++ b/org-metrics.html
@@ -4,12 +4,12 @@
 <head>
   <!--
   
-        After 90 seconds, head on over to Tweetbeam.
+        After 90 seconds, head on over to Current Metrics.
   
   -->
-  <meta http-equiv="refresh" content="90; url=tweetbeam.html">
+  <meta http-equiv="refresh" content="90; url=current-events.html">
 	<meta http-equiv="content-type" content="text/html; charset=utf-8">
-	<title>Code for America Project Monitor</title>
+	<title>Code for America Org Metrics</title>
 </head>
 <frameset rows="*, 40" border="0">
 <frame frameborder="0" scrolling="no" src="http://codeforamerica.github.io/cfa-numbers/">


### PR DESCRIPTION
This adds a new slide (current-events.html) that I'll change to reflect current goals. Right now it pulls summit % to goal and fellowship interest.
In addition to adding the slide, I've edited the readme and edited the org metrics slide to point to the new one, which then goes back to tweetbeam.
